### PR TITLE
doc: fix example of stages config

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,9 @@ An array of stages that the plugin will be included for. If this key is not spec
 
 ```yaml
 custom:
-  stages:
-      - prod
+  newRelic:
+    stages:
+       - prod
 ```
 
 #### `include` (optional)


### PR DESCRIPTION
The example of `stages` configuration is not correct. The `stages` block should be inside the `newRelic` block to make it work.